### PR TITLE
Revert "Pin postgres to 10.8"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
 
   database:
-    image: "postgres:10.8"
+    image: "postgres:10"
     environment:
       POSTGRES_USER: omero
       POSTGRES_DB: omero


### PR DESCRIPTION
Reverts ome/docker-example-omero#2 since now fixed. See https://github.com/ome/omero-install/issues/212 for more info.