### PR TITLE
Use latest OMERO versions for the default compose image

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ The initial password can be changed in [`docker-compose.yml`](docker-compose.yml
 
 ## Run
 
+First pull the latest major versions of the containers:
+
+    docker-compose pull
+
+Then start the containers:
+
     docker-compose up -d
     docker-compose logs -f
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - "database:/var/lib/postgresql/data"
 
   omeroserver:
-    image: "openmicroscopy/omero-server:5.6"
+    image: "openmicroscopy/omero-server:5"
     environment:
       CONFIG_omero_db_host: database
       CONFIG_omero_db_user: omero

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - "omero:/OMERO"
 
   omeroweb:
-    image: "openmicroscopy/omero-web-standalone:5.6"
+    image: "openmicroscopy/omero-web-standalone:5"
     environment:
       OMEROHOST: omeroserver
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - "database:/var/lib/postgresql/data"
 
   omeroserver:
+    # This container uses the tag for the latest server release of OMERO 5
+    # To upgrade to the next major release, increment the major version number
     image: "openmicroscopy/omero-server:5"
     environment:
       CONFIG_omero_db_host: database
@@ -30,6 +32,8 @@ services:
       - "omero:/OMERO"
 
   omeroweb:
+    # This container uses the tag for the latest web release of OMERO 5
+    # To upgrade to the next major release, increment the major version number
     image: "openmicroscopy/omero-web-standalone:5"
     environment:
       OMEROHOST: omeroserver


### PR DESCRIPTION
As noted on a recent forum post, the pinning of the OMERO.server and OMERO.web image to a minor version does no longer scale especially as the release cycle of OMERO.web is increasing and we want our default example to include the latest security fixes.

This PR proposes to use Docker Hub `latest` tag for both server and web base images. 
The advantage of this solution is to minimize our maintenance burden as we release new images. The downside is that it pushes the burden on an end-user to run `docker-compose pull` to get the latest versions of these images.
An alternative would be to update dependencies as part of the DOcker images releases. Ideally `dependabot` would be able to open a Pull Request but while Docker is supported as an ecosystem, I don't know whether it will deal with Docker Compose YML files - https://docs.github.com/en/code-security/supply-chain-security/about-dependabot-version-updates